### PR TITLE
Support zero and pointer literals and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A constructor for type `T` (only structs are supported at the moment) is a funct
 
 ## Current state
 
-The linter is in MVP state. It only reports non-zero, non-nil composite literals in the same package the type is defined.
+The linter is in MVP state. It only reports composite literals in the same package the type is defined.
 
 ## Usage
 
@@ -14,12 +14,10 @@ To be described later.
 
 ## Todo
 
-- Check for composite literals inside containers
 - Check types described in other packages
 - Check derived types (type T2 T)
 - Check type aliases (type T2 = T)
-- Check for composite literals in struct fields
-- Warn on zero and nil values being potentially unsafe if a constructor is defined for their type
+- Use different diagnostic message on zero and nil values
 - Add flags to switch zero/nil values warnings
 - Maybe check constructor returned value instead of its name to extract type (they often rename types without renaming constructors)
 - Support other constructor signatures

--- a/testdata/src/p/.golangci.yaml
+++ b/testdata/src/p/.golangci.yaml
@@ -1,0 +1,3 @@
+linters:
+  disable:
+    - unused

--- a/testdata/src/p/p.go
+++ b/testdata/src/p/p.go
@@ -26,19 +26,21 @@ type tDerived T
 type tAlias = T
 
 var (
-	// TODO: check for zero values
-	t = T{}
-	// TODO: check for nil values
-	t2         = &T{}
-	t3         = new(T)
-	tComposite = T{
+	t     = T{}  // want `use constructor NewT for type T instead of a composite literal`
+	t2    = &T{} // want `use constructor NewT for type T instead of a composite literal`
+	t3    = new(T)
+	justT = T{ // want `use constructor NewT for type T instead of a composite literal`
 		x: 1,
 		s: "abc",
 	}
-	tColl = []T{T{x: 1}}
+	ptrToT = &T{ // want `use constructor NewT for type T instead of a composite literal`
+		x: 1,
+		s: "abc",
+	}
+	tColl = []T{T{x: 1}} // want `use constructor NewT for type T instead of a composite literal`
 	n     = nested{
 		i: 1,
-		t: T{x: 1},
+		t: T{x: 1}, // want `use constructor NewT for type T instead of a composite literal`
 	}
 )
 
@@ -48,14 +50,21 @@ type nested struct {
 }
 
 func f() {
-	x := T{}
-	x2 := &T{}
+	x := T{}   // want `use constructor NewT for type T instead of a composite literal`
+	x2 := &T{} // want `use constructor NewT for type T instead of a composite literal`
+	// TODO: check nil values created with new
 	x3 := new(T)
 	fmt.Println(x, x2, x3)
 }
 
 func retT() T {
 	return T{ // want `use constructor NewT for type T instead of a composite literal`
+		x: 1,
+	}
+}
+
+func retPtrT() *T {
+	return &T{ // want `use constructor NewT for type T instead of a composite literal`
 		x: 1,
 	}
 }

--- a/testdata/src/p/p.go
+++ b/testdata/src/p/p.go
@@ -6,7 +6,7 @@ import "fmt"
 // NewT is a valid constructor for type T. Here we check if it's called
 // instead of constructing values of type T manually
 func NewT() *T {
-	return &T{
+	return &T{ // want `use constructor NewT for type T instead of a composite literal`
 		m: make(map[int]int),
 	}
 }
@@ -37,16 +37,29 @@ var (
 		x: 1,
 		s: "abc",
 	}
-	tColl = []T{T{x: 1}} // want `use constructor NewT for type T instead of a composite literal`
-	n     = nested{
-		i: 1,
-		t: T{x: 1}, // want `use constructor NewT for type T instead of a composite literal`
-	}
+	tColl    = []T{T{x: 1}}   // want `use constructor NewT for type T instead of a composite literal`
+	tPtrColl = []*T{&T{x: 1}} // want `use constructor NewT for type T instead of a composite literal`
+
 )
 
-type nested struct {
+type structWithTField struct {
 	i int
 	t T
+}
+
+var structWithT = structWithTField{
+	i: 1,
+	t: T{x: 1}, // want `use constructor NewT for type T instead of a composite literal`
+}
+
+type structWithTPtrField struct {
+	i int
+	t *T
+}
+
+var structWithTPtr = structWithTPtrField{
+	i: 1,
+	t: &T{x: 1}, // want `use constructor NewT for type T instead of a composite literal`
 }
 
 func f() {


### PR DESCRIPTION
- Fix bug with only the last literal stored in the map
- Check for zero literals
- Check for pointer literals
- Check for nil literals (only &T{}, not new(T))
- Check for T and *t values inside composite literals (slices, other structs...)